### PR TITLE
Add -e to shell invocation

### DIFF
--- a/code/SLURM/run_analysis.sl
+++ b/code/SLURM/run_analysis.sl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #SBATCH -J array-analysis.R
 #SBATCH -A project_code # Nesi project code eg nesi99999 or uoo99999
 #SBATCH --time=5:00     # Walltime

--- a/code/SLURM/run_array-analysis.sl
+++ b/code/SLURM/run_array-analysis.sl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #SBATCH -J array-analysis.R
 #SBATCH -A project_code # Nesi project code eg nesi99999 or uoo99999
 #SBATCH --time=5:00     # Walltime

--- a/code/SLURM/run_print-args.sl
+++ b/code/SLURM/run_print-args.sl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #SBATCH -J print-args.R
 #SBATCH -A project_code # Nesi project code eg nesi99999 or uoo99999
 #SBATCH --time=5:00     # Walltime

--- a/code/SLURM/run_simple.sl
+++ b/code/SLURM/run_simple.sl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #SBATCH -J simple.R
 #SBATCH -A project_code # Nesi project code eg nesi99999 or uoo99999
 #SBATCH --time=01:00     # Walltime


### PR DESCRIPTION
This flag will cause the job to fail whenever a _simple_ command exits with non-zero status. We recommend it in all job submissions.